### PR TITLE
Remove CPM.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ DownloadFile(
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPM.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/AddTargetHelper.cmake)
 
+# FetchContentを有効にする
+include(FetchContent)
+
 # CPMを用いてネット上のパッケージを取り込む
 set(MSGPACK_CXX20 ON)
 CPMAddPackage(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,29 +48,31 @@ include(FetchContent)
 
 # CPMを用いてネット上のパッケージを取り込む
 set(MSGPACK_CXX20 ON)
-CPMAddPackage(
-    NAME msgpack-cxx
-    GITHUB_REPOSITORY msgpack/msgpack-c 
+FetchContent_Declare(
+    msgpack-cxx
+    GIT_REPOSITORY https://github.com/msgpack/msgpack-c.git
     GIT_TAG cpp-6.1.0
 )
 
-CPMAddPackage(
-    NAME challenger
-    GITHUB_REPOSITORY Y-T10/challenger 
+FetchContent_Declare(
+    challenger
+    GIT_REPOSITORY https://github.com/Y-T10/challenger.git
     GIT_TAG v0.0.1
 )
 
-CPMAddPackage(
-    NAME IMGUI
-    GITHUB_REPOSITORY ocornut/imgui
+FetchContent_Declare(
+    IMGUI
+    GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG v1.90.8
 )
 
-CPMAddPackage(
-    NAME Fcpp
-    GITHUB_REPOSITORY Y-T10/Fcpp
+FetchContent_Declare(
+    Fcpp
+    GIT_REPOSITORY https://github.com/Y-T10/Fcpp.git
     GIT_TAG main
 )
+
+FetchContent_MakeAvailable(msgpack-cxx challenger IMGUI Fcpp)
 
 # システム内のパッケージを読み込む
 find_package(Threads REQUIRED)

--- a/src/ModImGui/CMakeLists.txt
+++ b/src/ModImGui/CMakeLists.txt
@@ -4,16 +4,16 @@ add_library(ModImGui)
 # リンクディレクトリに追加
 target_include_directories(ModImGui PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/
-    "${IMGUI_SOURCE_DIR}/"
+    "${imgui_SOURCE_DIR}/"
 )
 
 # ターゲットのビルド情報を設定する
 target_sources(ModImGui PRIVATE
-    ${IMGUI_SOURCE_DIR}/imgui.cpp
-    ${IMGUI_SOURCE_DIR}/imgui_demo.cpp
-    ${IMGUI_SOURCE_DIR}/imgui_draw.cpp
-    ${IMGUI_SOURCE_DIR}/imgui_tables.cpp
-    ${IMGUI_SOURCE_DIR}/imgui_widgets.cpp
+    ${imgui_SOURCE_DIR}/imgui.cpp
+    ${imgui_SOURCE_DIR}/imgui_demo.cpp
+    ${imgui_SOURCE_DIR}/imgui_draw.cpp
+    ${imgui_SOURCE_DIR}/imgui_tables.cpp
+    ${imgui_SOURCE_DIR}/imgui_widgets.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/imgui_impl_sdl3.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/imgui_impl_sdlrenderer3.cpp
 )


### PR DESCRIPTION
## やったこと
- CPMからFetchContentに変更した
  * 開発が遅く、最新のCMakeに適合できていないため
  * FetchContentに対するCPMの利点を生かしていないため

## これからやること
- 依存している自作ライブラリにもこの変更を適用する
- 適用後、cmakeからCPM関連のスクリプトを消す